### PR TITLE
Inform Customer targetDirectory Parameter will be ignored in Zip Deploy

### DIFF
--- a/src/main/java/com/microsoft/jenkins/function/commands/ZipDeployCommand.java
+++ b/src/main/java/com/microsoft/jenkins/function/commands/ZipDeployCommand.java
@@ -15,6 +15,7 @@ import com.microsoft.jenkins.function.util.Constants;
 import hudson.FilePath;
 import hudson.Util;
 import hudson.util.DirScanner;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -31,6 +32,11 @@ public class ZipDeployCommand implements ICommand<ZipDeployCommand.IZipDeployCom
 
         final FilePath tempDir;
         try {
+            String targetDirectory = context.getTargetDirectory();
+            if (StringUtils.isNotBlank(targetDirectory)) {
+                context.logStatus(String.format("Your parameter %s for Target Directory will be ignored "
+                        + "for Java functions.", targetDirectory));
+            }
             tempDir = workspace.createTempDir(ZIP_FOLDER_NAME, null);
             final FilePath zipPath = tempDir.child(ZIP_NAME);
             final DirScanner.Glob globScanner = new DirScanner.Glob(filePattern, excludedFilesAndZip());

--- a/src/test/java/com/microsoft/jenkins/function/integration/ITZipDeployCommand.java
+++ b/src/test/java/com/microsoft/jenkins/function/integration/ITZipDeployCommand.java
@@ -84,6 +84,7 @@ public class ITZipDeployCommand extends IntegrationTest {
                 .define(testEnv.appServiceName)
                 .withRegion(Region.US_WEST)
                 .withExistingResourceGroup(testEnv.azureResourceGroup)
+                .withLatestRuntimeVersion()
                 .create();
         TimeUnit.SECONDS.sleep(10);
         Assert.assertNotNull(function);


### PR DESCRIPTION
1. Have confirmed with Sheng, Java function do not support nesting structure for functions, all the functions should be put at the wwwroot folder. 
2. A little change for zip integration test.